### PR TITLE
Job date validation

### DIFF
--- a/frontend/src/Jobs.tsx
+++ b/frontend/src/Jobs.tsx
@@ -290,10 +290,10 @@ const JobPage: React.FC<JobPageProps> = () => {
   return (
     <div className="max-w-screen-md mx-auto p-6">
       <Tab.Group>
-        <Tab.List className="flex bg-gray-100 p-4 rounded-t-md">
+        <Tab.List className="flex flex-wrap text-sm font-medium text-center text-gray-500 border-b border-gray-200">
           <Tab
             className={({ selected }) =>
-              selected ? "bg-white text-blue-500" : "bg-gray-200 text-gray-600"
+                selected ? "inline-block p-4 text-gray-800 bg-gray-300 rounded-t-lg" : "inline-block p-4 bg-gray-50 rounded-t-lg hover:text-gray-600 hover:bg-gray-100 "
             }
             onClick={() => setActiveTab("view")}
           >
@@ -301,7 +301,7 @@ const JobPage: React.FC<JobPageProps> = () => {
           </Tab>
           <Tab
             className={({ selected }) =>
-              selected ? "bg-white text-blue-500" : "bg-gray-200 text-gray-600"
+                selected ? "inline-block p-4 text-gray-800 bg-gray-300 rounded-t-lg ml-1" : "inline-block p-4 bg-gray-50 rounded-t-lg ml-1 hover:text-gray-600 hover:bg-gray-100 "
             }
             onClick={() => setActiveTab("add")}
           >
@@ -321,7 +321,7 @@ const JobPage: React.FC<JobPageProps> = () => {
                   name="pet"
                   value={jobFormData.pet}
                   onChange={(e) => setJobFormData({ ...jobFormData, pet: e.target.value })}
-                  className="border border-gray-300 rounded-md p-2 mt-1"
+                  className="border border-gray-300 rounded-md p-2 mt-1 w-1/4"
                 >
                   <option value="" disabled>
                     Select a pet
@@ -332,12 +332,15 @@ const JobPage: React.FC<JobPageProps> = () => {
                     </option>
                   ))}
                 </select>
+                <label htmlFor="location-dropdown" className="block text-sm font-medium text-gray-700">
+                  Select a Location
+                </label>
                 <select
                   id="location-dropdown"
                   name="location"
                   value={jobFormData.location}
                   onChange={(e) => setJobFormData({ ...jobFormData, location: e.target.value })}
-                  className="border border-gray-300 rounded-md p-2 mt-1"
+                  className="border border-gray-300 rounded-md p-2 mt-1 w-1/3"
                 >
                   <option value="" disabled>
                     Select a Location

--- a/frontend/src/Jobs.tsx
+++ b/frontend/src/Jobs.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from "react";
+import React, {useEffect, useState} from "react";
 import axios from "axios";
-import { Tab } from "@headlessui/react";
-import { API_ROUTES } from "./constants";
+import {Tab} from "@headlessui/react";
+import {API_ROUTES} from "./constants";
 import toast from "react-hot-toast";
 import ApplicationModal from "./ApplicationModal";
 
@@ -245,6 +245,13 @@ const JobPage: React.FC<JobPageProps> = () => {
       });
   };
   const onClickSave = () => {
+    try {
+      checkDates();
+    }
+    catch (error){
+      toast.error(error.message);
+      return;
+    }
     const saveConsent = window.confirm("Are you sure you want to make these changes?");
     if (saveConsent) {
       console.log(jobFormData);
@@ -253,7 +260,7 @@ const JobPage: React.FC<JobPageProps> = () => {
         .post(API_ROUTES.JOBS, jobFormData)
         .then((response) => {
           if (response.status === 201) {
-            toast.success("Job Addedd Successfully");
+            toast.success("Job Added Successfully");
             setJobFormData({
               pet: "",
               location: "",
@@ -284,6 +291,67 @@ const JobPage: React.FC<JobPageProps> = () => {
         status: "",
         end: "",
       });
+    }
+  };
+
+  const getCurrentDateTime = () => {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = (now.getMonth() + 1).toString().padStart(2, '0');
+    const day = now.getDate().toString().padStart(2, '0');
+    const hour = now.getHours().toString().padStart(2, '0');
+    const minute = now.getMinutes().toString().padStart(2, '0');
+
+    return `${year}-${month}-${day}T${hour}:${minute}`;
+  };
+
+  const handleStartUpdate = (e) => {
+    if (e.target.value)
+    {
+      const selectedStart = new Date(e.target.value);
+      const now = new Date();
+
+      if (selectedStart > now)
+      {
+        setJobFormData({ ...jobFormData, start: e.target.value});
+      }
+      else
+      {
+        setJobFormData({ ...jobFormData, start: ""});
+        toast.error("Start datetime must be in the future.");
+      }
+    }
+  };
+
+  const handleEndUpdate = (e) => {
+    if (e.target.value)
+    {
+      const startDate = new Date(jobFormData.start);
+      const selectedEndDate = new Date(e.target.value);
+
+      if (selectedEndDate > startDate)
+      {
+        setJobFormData({ ...jobFormData, end: e.target.value});
+      }
+      else
+      {
+        toast.error("End datetime must be after start.");
+      }
+    }
+  };
+
+  const checkDates = () => {
+    const startDateTime = new Date(jobFormData.start);
+    const endDateTime = new Date(jobFormData.end);
+    const now = new Date();
+
+    if (startDateTime <= now)
+    {
+      throw new Error("Start date time must be in the future.");
+    }
+    else if (endDateTime <= startDateTime)
+    {
+      throw new Error("End date time must be after start.")
     }
   };
 
@@ -369,9 +437,10 @@ const JobPage: React.FC<JobPageProps> = () => {
                 <input
                   type="datetime-local"
                   name="start"
+                  min={getCurrentDateTime()}
                   id="job-start"
                   value={jobFormData.start}
-                  onChange={(e) => setJobFormData({ ...jobFormData, start: e.target.value })}
+                  onChange={(e) => handleStartUpdate(e)}
                   className="border border-gray-300 rounded-md p-2 mt-1"
                 />
 
@@ -382,8 +451,9 @@ const JobPage: React.FC<JobPageProps> = () => {
                   type="datetime-local"
                   name="end"
                   id="job-end"
+                  min={jobFormData.start}
                   value={jobFormData.end}
-                  onChange={(e) => setJobFormData({ ...jobFormData, end: e.target.value })}
+                  onChange={(e) => handleEndUpdate(e)}
                   className="border border-gray-300 rounded-md p-2 mt-1"
                 />
               </div>

--- a/frontend/src/PetProfiles.tsx
+++ b/frontend/src/PetProfiles.tsx
@@ -366,10 +366,10 @@ const PetProfilePage: React.FC<PetProfilePageProps> = () => {
   return (
     <div className="max-w-screen-md mx-auto p-6">
       <Tab.Group>
-        <Tab.List className="flex bg-gray-100 p-4 rounded-t-md">
+        <Tab.List className="flex flex-wrap text-sm font-medium text-center text-gray-500 border-b border-gray-200">
           <Tab
             className={({ selected }) =>
-              selected ? "bg-white text-blue-500" : "bg-gray-200 text-gray-600"
+                selected ? "inline-block p-4 text-gray-800 bg-gray-300 rounded-t-lg" : "inline-block p-4 bg-gray-50 rounded-t-lg hover:text-gray-600 hover:bg-gray-100 "
             }
             onClick={() => setActiveTab("view")}
           >
@@ -377,7 +377,7 @@ const PetProfilePage: React.FC<PetProfilePageProps> = () => {
           </Tab>
           <Tab
             className={({ selected }) =>
-              selected ? "bg-white text-blue-500" : "bg-gray-200 text-gray-600"
+                selected ? "inline-block p-4 text-gray-800 bg-gray-300 rounded-t-lg ml-1" : "inline-block p-4 bg-gray-50 rounded-t-lg ml-1 hover:text-gray-600 hover:bg-gray-100 "
             }
             onClick={() => setActiveTab("add")}
           >

--- a/frontend/src/PetProfiles.tsx
+++ b/frontend/src/PetProfiles.tsx
@@ -22,6 +22,10 @@ interface EditPetFormData {
   species: string;
   breed: string;
   weight: string;
+  color: string;
+  height: string;
+  chip_number: string;
+  health_requirements: string;
   pictures: string[];
 }
 
@@ -37,6 +41,10 @@ const PetProfiles: React.FC = () => {
     species: "",
     breed: "",
     weight: "",
+    color: "",
+    height: "",
+    chip_number: "",
+    health_requirements: "",
   });
 
   useEffect(() => {
@@ -86,6 +94,10 @@ const PetProfiles: React.FC = () => {
       species: pet.species,
       breed: pet.breed,
       weight: pet.weight,
+      color: pet.color,
+      height: pet.height,
+      chip_number: pet.chip_number,
+      health_requirements: pet.health_requirements,
     });
   };
 
@@ -96,6 +108,10 @@ const PetProfiles: React.FC = () => {
       species: "",
       breed: "",
       weight: "",
+      color: "",
+      height: "",
+      chip_number: "",
+      health_requirements: "",
     });
   };
 
@@ -108,6 +124,10 @@ const PetProfiles: React.FC = () => {
           species: editFormData.species,
           breed: editFormData.breed,
           weight: editFormData.weight,
+          color: editFormData.color,
+          height: editFormData.height,
+          chip_number: editFormData.chip_number,
+          health_requirements: editFormData.health_requirements,
         });
 
         if (response.status === 200) {
@@ -120,6 +140,10 @@ const PetProfiles: React.FC = () => {
               species: editFormData.species,
               breed: editFormData.breed,
               weight: editFormData.weight,
+              color: editFormData.color,
+              height: editFormData.height,
+              chip_number: editFormData.chip_number,
+              health_requirements: editFormData.health_requirements,
             };
             setPets(updatedPets);
           }
@@ -181,6 +205,24 @@ const PetProfiles: React.FC = () => {
                       onChange={(e) => setEditFormData({ ...editFormData, breed: e.target.value })}
                       className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
                     />
+                    <label htmlFor="edit-color">Color</label>
+                    <input
+                      type="text"
+                      name="color"
+                      id="edit-color"
+                      value={editFormData.color}
+                      onChange={(e) => setEditFormData({...editFormData, color:e.target.value})}
+                      className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                      />
+                    <label htmlFor="edit-height">Height</label>
+                    <input
+                      type="text"
+                      name="height"
+                      id="edit-height"
+                      value={editFormData.height}
+                      onChange={(e) => setEditFormData({...editFormData, height:e.target.value})}
+                      className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                      />
                     <label htmlFor="edit-weight">Weight</label>
                     <input
                       type="text"
@@ -188,6 +230,24 @@ const PetProfiles: React.FC = () => {
                       id="edit-weight"
                       value={editFormData.weight}
                       onChange={(e) => setEditFormData({ ...editFormData, weight: e.target.value })}
+                      className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                    />
+                    <label htmlFor="edit-chip_number">Chip Number</label>
+                    <input
+                      type="text"
+                      name="chip_number"
+                      id="edit-chip_number"
+                      value={editFormData.chip_number}
+                      onChange={(e) => setEditFormData({ ...editFormData, chip_number: e.target.value })}
+                      className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                    />
+                    <label htmlFor="edit-health_requirements">Health Requirements</label>
+                    <input
+                      type="text"
+                      name="health_requirements"
+                      id="edit-health_requirements"
+                      value={editFormData.health_requirements}
+                      onChange={(e) => setEditFormData({ ...editFormData, health_requirements: e.target.value })}
                       className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
                     />
                   </form>
@@ -211,9 +271,9 @@ const PetProfiles: React.FC = () => {
                   <p className="font-bold mb-2">Name: {pet.name}</p>
                   <p>Species: {pet.species}</p>
                   <p>Breed: {pet.breed}</p>
-                  <p>Weight: {pet.weight}</p>
                   <p>Color: {pet.color}</p>
                   <p>Height: {pet.height}</p>
+                  <p>Weight: {pet.weight}</p>
                   <p>Chip Number: {pet.chip_number}</p>
                   <p>Health Requirements: {pet.health_requirements}</p>
                 </div>
@@ -351,6 +411,17 @@ const PetProfilePage: React.FC<PetProfilePageProps> = () => {
                   onChange={(e) => setPetFormData({ ...petFormData, species: e.target.value })}
                   className="border border-gray-300 rounded-md p-2 mt-1"
                 />
+                <label htmlFor="pet-breed" className="block text-sm font-medium text-gray-700">
+                  Breed
+                </label>
+                <input
+                  type="text"
+                  name="breed"
+                  id="pet-breed"
+                  value={petFormData.breed}
+                  onChange={(e) => setPetFormData({ ...petFormData, breed: e.target.value })}
+                  className="border border-gray-300 rounded-md p-2 mt-1"
+                />
                 <label htmlFor="pet-color" className="block text-sm font-medium text-gray-700">
                   Color
                 </label>
@@ -372,17 +443,6 @@ const PetProfilePage: React.FC<PetProfilePageProps> = () => {
                   id="pet-height"
                   value={petFormData.height}
                   onChange={(e) => setPetFormData({ ...petFormData, height: e.target.value })}
-                  className="border border-gray-300 rounded-md p-2 mt-1"
-                />
-                <label htmlFor="pet-breed" className="block text-sm font-medium text-gray-700">
-                  Breed
-                </label>
-                <input
-                  type="text"
-                  name="breed"
-                  id="pet-breed"
-                  value={petFormData.breed}
-                  onChange={(e) => setPetFormData({ ...petFormData, breed: e.target.value })}
                   className="border border-gray-300 rounded-md p-2 mt-1"
                 />
                 <label htmlFor="pet-weight" className="block text-sm font-medium text-gray-700">

--- a/furbaby/api/views.py
+++ b/furbaby/api/views.py
@@ -1,5 +1,7 @@
 import json
 import os
+from datetime import datetime, timezone, timedelta
+
 from django.http import JsonResponse, HttpResponse
 from django.contrib.auth import login, logout
 from drf_standardized_errors.handler import exception_handler
@@ -728,10 +730,21 @@ class PetRetrieveUpdateDeleteView(RetrieveUpdateDestroyAPIView):
 class JobView(APIView):
     permission_classes = [IsAuthenticated]
 
+    def job_status_check(self):
+        to_be_cancelled_queryset = Jobs.objects.filter(status="open").filter(start__lte=datetime.now(timezone.utc)
+                                                                                        - timedelta(hours=5))
+        for job in to_be_cancelled_queryset:
+            if job.status == "open":
+                job.status = "cancelled"
+                job.save()
+        return
+
     def get_all(self):
-        return Jobs.objects.all()
+        self.job_status_check()
+        return Jobs.objects.filter(status="open")
 
     def get_queryset(self):
+        self.job_status_check()
         return Jobs.objects.filter(user_id=self.request.user.id)
 
     def get_object(self, job_id):


### PR DESCRIPTION
Frontend changes:

Users can only select start dates into the future and end dates after start dates. In case selected start date is modified to be after end date, an error will be thrown asking to select an end date after the start date.

![Screenshot 2023-12-04 142901](https://github.com/gcivil-nyu-org/INET-Monday-Fall2023-Team-1/assets/71821708/89df46bb-8676-4cd9-9fb7-4a18b23f9f25)
![Screenshot 2023-12-04 142914](https://github.com/gcivil-nyu-org/INET-Monday-Fall2023-Team-1/assets/71821708/329c1121-2439-415b-b55f-8a09033cb4a8)
![Screenshot 2023-12-04 142926](https://github.com/gcivil-nyu-org/INET-Monday-Fall2023-Team-1/assets/71821708/360c97e6-12bf-47ef-b4f9-8aced786dadb)
![Screenshot 2023-12-04 142938](https://github.com/gcivil-nyu-org/INET-Monday-Fall2023-Team-1/assets/71821708/52af23f3-3096-4d5e-b6b8-992bc3f72863)


Backend changes:

Whenever a pet sitter or pet owner fetches the list of jobs, a check will be made on all open jobs. If an open job has a start date/time that has already passed, the job will be marked as cancelled.